### PR TITLE
Jammers - Fix staying jammed on last jammer removal

### DIFF
--- a/addons/jammers/functions/fnc_jammerHandlerClient.sqf
+++ b/addons/jammers/functions/fnc_jammerHandlerClient.sqf
@@ -39,6 +39,8 @@ _condition = {
 _exitCode = {
     INFO("No active jammers left, removing client PFH.");
     GVAR(jammerHandlerClient) = -1;
+    ace_player setVariable ["tf_receivingDistanceMultiplicator", 1];
+    ace_player setVariable ["tf_sendingDistanceMultiplicator", 1];
 };
 
 _jammerHandler = [

--- a/addons/jammers/functions/fnc_jammerHandlerClient.sqf
+++ b/addons/jammers/functions/fnc_jammerHandlerClient.sqf
@@ -39,8 +39,8 @@ _condition = {
 _exitCode = {
     INFO("No active jammers left, removing client PFH.");
     GVAR(jammerHandlerClient) = -1;
-    ace_player setVariable ["tf_receivingDistanceMultiplicator", 1];
-    ace_player setVariable ["tf_sendingDistanceMultiplicator", 1];
+    ace_player setVariable ["tf_receivingDistanceMultiplicator", nil];
+    ace_player setVariable ["tf_sendingDistanceMultiplicator", nil];
 };
 
 _jammerHandler = [


### PR DESCRIPTION
## Description
Fixed players remaining jammed after the last jammer is removed.

## Changes
- Reset player interference on client PFH exit code.