### PR TITLE
Core/Medical - Fix various FX-7 bugs

### DIFF
--- a/addons/core/functions/fnc_soundLoop.sqf
+++ b/addons/core/functions/fnc_soundLoop.sqf
@@ -27,7 +27,7 @@ params [
 private ["_function"];
 TRACE_4("fnc_soundLoop",_object,_filePath,_delay,_condition);
 
-if (isNull _object or {
+if (!alive _object or {
     _filePath isEqualTo "" or
     !([_object, _filePath, _delay] call _condition)
 }) exitWith {};
@@ -35,7 +35,7 @@ playSound3D [_filePath, objNull, false, getPosASL _object, 1, 1, 50];
 
 _function = {
     params ["_object", "_filePath", "_delay", "_function"];
-    if (isNull _object or !([_object, _filePath, _delay] call _condition)) exitWith {};
+    if (!alive _object or !([_object, _filePath, _delay] call _condition)) exitWith {};
     playSound3D [_filePath, objNull, false, getPosASL _object, 1, 1, 50];
 
     [{

--- a/addons/core/functions/fnc_soundLoopInit.sqf
+++ b/addons/core/functions/fnc_soundLoopInit.sqf
@@ -19,7 +19,7 @@ params [
 private ["_filePath", "_soundDelay"];
 TRACE_1("fnc_soundLoopInit",_object);
 
-if (isNull _object) exitWith {};
+if (!alive _object) exitWith {};
 
 _filePath = getText (configOf _object >> QGVAR(soundLoop));
 _soundDelay = getNumber (configOf _object >> QGVAR(soundLoopDelay));

--- a/addons/medical/CfgVehicles.hpp
+++ b/addons/medical/CfgVehicles.hpp
@@ -1,7 +1,7 @@
 class CfgVehicles
 {
-    class ThingX;
-    class CLASS(Deployable_MedicalDroid): ThingX {
+    class Land_3AS_Medical_Droid;
+    class CLASS(Deployable_MedicalDroid): Land_3AS_Medical_Droid {
         SCOPE_PUBLIC;
 
         displayName = "FX-7 Medical Droid";

--- a/addons/medical/config.cpp
+++ b/addons/medical/config.cpp
@@ -19,7 +19,8 @@ class CfgPatches {
             "ace_medical_statemachine",
             "ace_medical_status",
             "ace_medical_treatment",
-            "ace_medical_vitals"
+            "ace_medical_vitals",
+            "3AS_Prop_Droids"
         };
         units[] = {
             QCLASS(Deployable_MedicalDroid),

--- a/addons/medical/functions/fnc_areaSlowHeal.sqf
+++ b/addons/medical/functions/fnc_areaSlowHeal.sqf
@@ -87,6 +87,7 @@ _function = {
 
         _healHandlerID = [_x, _rate, _bloodRestore, _painReduce, _fullHealOnCompletion] call FUNC(slowHeal);
         _currentPatients pushBack [_x, _healHandlerID];
+        ["ace_common_displayTextStructured", ["You are now being treated."], _x] call CBA_fnc_targetEvent;
 
         _object setVariable [QGVAR(currentPatients), _currentPatients, true];
     } forEach (_unitsToHeal - (_currentPatients apply {_x#0}));

--- a/addons/medical/functions/fnc_slowHeal.sqf
+++ b/addons/medical/functions/fnc_slowHeal.sqf
@@ -98,6 +98,7 @@ _exitCode = {
     INFO_2("Slow Healer %1 | (Exit) Removing handler from %2",_handle,_unit);
     _unit setVariable [QGVAR(slowHealHandler), nil];
     _unit setVariable [QGVAR(canBeHealed), nil];
+    ["ace_common_displayTextStructured", ["You are no longer being treated."], _x] call CBA_fnc_targetEvent;
 };
 
 _healHandler = [


### PR DESCRIPTION
## Description
Added a message to players being healed by an FX-7 / bacta grenade as a visual indicator for being healed. Updated inheritance for FX-7 to fix it spawning in lopsided.

## Changes
- Added message when player starts/stops being healed by FX-7/bacta.
- Updated inheritance for FX-7.
  - Had an issue where the FX-7 would be affected by gravity.
  - Potentially caused the droid to be destroyed on spawn.
- Added utility function to disable damage temporarily.