### PR TITLE
Weapons - Increased Westar-M5 magazine capacity

### DIFF
--- a/addons/factions/rdf/CfgVehicles.hpp
+++ b/addons/factions/rdf/CfgVehicles.hpp
@@ -205,11 +205,11 @@ class CfgVehicles {
         respawnWeapons[] = {QCLASS(WestarM5), QCLASS(DC15SA), "Throw", "Put"};
 
         magazines[] = {
-            QCLASS(Mag_60rnd_WestarM5),
+            QCLASS(Mag_99Rnd_WestarM5),
             QCLASS(Mag_30Rnd_DC15SA)
         };
         respawnMagazines[] = {
-            QCLASS(Mag_60rnd_WestarM5),
+            QCLASS(Mag_99Rnd_WestarM5),
             QCLASS(Mag_30Rnd_DC15SA)
         };
 
@@ -226,11 +226,11 @@ class CfgVehicles {
         respawnWeapons[] = {QCLASS(WestarM5), QCLASS(DC15SA), "Aux501_Weaps_Z1000", "Throw", "Put"};
 
         magazines[] = {
-            QCLASS(Mag_60rnd_WestarM5),
+            QCLASS(Mag_99Rnd_WestarM5),
             QCLASS(Mag_30Rnd_DC15SA)
         };
         respawnMagazines[] = {
-            QCLASS(Mag_60rnd_WestarM5),
+            QCLASS(Mag_99Rnd_WestarM5),
             QCLASS(Mag_30Rnd_DC15SA)
         };
 
@@ -320,7 +320,7 @@ class CfgVehicles {
         SCOPE_HIDDEN;
 
         class TransportMagazines {
-            MAG_XX(CLASS(Mag_60rnd_WestarM5),15);
+            MAG_XX(CLASS(Mag_99Rnd_WestarM5),15);
             MAG_XX(CLASS(Mag_30Rnd_DC15SA),5);
             MAG_XX(CLASS(Mag_15Rnd_DC15SA),5);
             MAG_XX(CLASS(Mag_7Rnd_DC15SA),5);
@@ -341,7 +341,7 @@ class CfgVehicles {
 
     class CLASS(RDF_Backpack_SWAT_Predef_Chaingun): CLASS(RDF_Backpack_SWAT_Predef_Rifleman) {
         class TransportMagazines: TransportMagazines {
-            MAG_XX(CLASS(Mag_60rnd_WestarM5),15);
+            MAG_XX(CLASS(Mag_99Rnd_WestarM5),15);
             MAG_XX(CLASS(Mag_30Rnd_DC15SA),5);
             MAG_XX(CLASS(Mag_15Rnd_DC15SA),5);
             MAG_XX(CLASS(Mag_7Rnd_DC15SA),5);

--- a/addons/objects/resupply/CfgVehicles.hpp
+++ b/addons/objects/resupply/CfgVehicles.hpp
@@ -42,7 +42,7 @@ class CfgVehicles {
             MAG_XX(CLASS(Mag_15Rnd_DC15X),10);
             MAG_XX(CLASS(Mag_240Rnd_DC15L),10);
             MAG_XX(CLASS(Mag_30Rnd_DP23),10);
-            MAG_XX(CLASS(Mag_60Rnd_WestarM5),10);
+            MAG_XX(CLASS(Mag_99Rnd_WestarM5),10);
             MAG_XX(CLASS(Mag_25Rnd_Valken38x),10);
 
             // UGL Ammo
@@ -87,7 +87,7 @@ class CfgVehicles {
             MAG_XX(CLASS(Mag_15Rnd_DC15X),160);
             MAG_XX(CLASS(Mag_240Rnd_DC15L),160);
             MAG_XX(CLASS(Mag_30Rnd_DP23),160);
-            MAG_XX(CLASS(Mag_60Rnd_WestarM5),160);
+            MAG_XX(CLASS(Mag_99Rnd_WestarM5),160);
             MAG_XX(CLASS(Mag_25Rnd_Valken38x),160);
 
             // UGL Ammo

--- a/addons/weapons/westar_m5/CfgMagazines.hpp
+++ b/addons/weapons/westar_m5/CfgMagazines.hpp
@@ -1,22 +1,22 @@
 class CfgMagazines {
     class CLASS(Mag_Base);
-    class CLASS(Mag_60Rnd_WestarM5): CLASS(Mag_Base) {
+    class CLASS(Mag_99Rnd_WestarM5): CLASS(Mag_Base) {
         SCOPE_PUBLIC;
         displayName = "[KC] Westar-M5 Energy Cell";
         displayNameShort = "Standard Energy";
-        descriptionShort = "Energy Cell Pack<br/>Rounds: 60<br/>Used In: Westar-M5";
+        descriptionShort = "Energy Cell Pack<br/>Rounds: 99<br/>Used In: Westar-M5";
 
         model = "\SWLW_clones\smgs\westar_m5\WestarM5_mag.p3d";
         picture = "\SWLW_clones\smgs\westar_m5\data\ui\WestarM5_mag_ui.paa";
 
         ammo = QCLASS(Bullet_PlasmaRifle_Blue);
-        count = 60;
+        count = 99;
         initSpeed = 472;
         mass = 10;
     };
 
-    class Aux12thFleet_Mag_WestarM5: CLASS(Mag_60Rnd_WestarM5) {
+    class Aux12thFleet_Mag_WestarM5: CLASS(Mag_99Rnd_WestarM5) {
         SCOPE_HIDDEN;
-        descriptionShort = "Energy Cell Pack<br/>Rounds: 60<br/>Used In: Westar-M5<br/>LEGACY CLASS<br/>This class has been deprecated and will be removed in the future.";
+        descriptionShort = "Energy Cell Pack<br/>Rounds: 99<br/>Used In: Westar-M5<br/>LEGACY CLASS<br/>This class has been deprecated and will be removed in the future.";
     };
 };

--- a/addons/weapons/westar_m5/CfgWeapons.hpp
+++ b/addons/weapons/westar_m5/CfgWeapons.hpp
@@ -35,7 +35,7 @@ class CfgWeapons {
 
         modes[] = {"Single", "Burst", "FullAuto"};
         muzzles[] = {"this"};
-        magazines[] = {QCLASS(Mag_60Rnd_WestarM5), "Aux12thFleet_Mag_WestarM5"};
+        magazines[] = {QCLASS(Mag_99Rnd_WestarM5), "Aux12thFleet_Mag_WestarM5"};
         magazineWell[] = {};
 
         canShootInWater = TRUE;


### PR DESCRIPTION
## Description
Increased Westar-M5 magazine capacity.

<!--
If multiple components are being modified, add **Component Name** to the beginning of each list.
e.g.
**Core**
- Change 1

**Weapons**
- Change 1
-->
## Changes
- Increased Westar-M5 magazine capacity to 99 rounds.