### PR TITLE
Xeh fix

### DIFF
--- a/addons/core/CfgEventHandlers.hpp
+++ b/addons/core/CfgEventHandlers.hpp
@@ -12,7 +12,6 @@ class Extended_PreInit_EventHandlers {
 
 class Extended_PostInit_EventHandlers {
     class ADDON {
-        clientInit = QUOTE(call COMPILE_SCRIPT(XEH_postInitClient));
-        serverInit = QUOTE(call COMPILE_SCRIPT(XEH_postInitServer));
+        init = QUOTE(call COMPILE_SCRIPT(XEH_postInit));
     };
 };

--- a/addons/core/XEH_postInit.sqf
+++ b/addons/core/XEH_postInit.sqf
@@ -1,0 +1,9 @@
+#include "script_component.hpp"
+
+if (isServer) then {
+    call COMPILE_SCRIPT(XEH_postInitServer)
+};
+
+if (hasInterface) then {
+    call COMPILE_SCRIPT(XEH_postInitClient)
+};

--- a/addons/fortify/CfgEventHandlers.hpp
+++ b/addons/fortify/CfgEventHandlers.hpp
@@ -12,6 +12,6 @@ class Extended_PreInit_EventHandlers {
 
 class Extended_PostInit_EventHandlers {
     class ADDON {
-        serverInit = QUOTE(call COMPILE_SCRIPT(XEH_postInitServer));
+        init = QUOTE(call COMPILE_SCRIPT(XEH_postInit));
     };
 };

--- a/addons/fortify/XEH_postInit.sqf
+++ b/addons/fortify/XEH_postInit.sqf
@@ -1,0 +1,5 @@
+#include "script_component.hpp"
+
+if (isServer) then {
+    call COMPILE_SCRIPT(XEH_postInitServer)
+};

--- a/addons/jammers/CfgEventHandlers.hpp
+++ b/addons/jammers/CfgEventHandlers.hpp
@@ -19,13 +19,13 @@ class Extended_PostInit_EventHandlers {
 class Extended_Init_EventHandlers {
     class GVAR(communicationTower) {
         class GVAR(init) {
-            init = QUOTE([ARR_3(_this#0,5000,150)] call FUNC(addJammer));
+            serverInit = QUOTE([ARR_4(_this#0,5000,150,true)] call FUNC(addJammerServer));
         };
     };
 
     class CLASS(CIS_Unit_Droid_B1_Saboteur) {
         class GVAR(init) {
-            init = QUOTE([ARR_2(_this#0,100)] call FUNC(addJammer));
+            serverInit = QUOTE([ARR_4(_this#0,100,100,true)] call FUNC(addJammerServer));
         };
     };
 };

--- a/addons/jammers/CfgEventHandlers.hpp
+++ b/addons/jammers/CfgEventHandlers.hpp
@@ -12,8 +12,7 @@ class Extended_PreInit_EventHandlers {
 
 class Extended_PostInit_EventHandlers {
     class ADDON {
-        clientInit = QUOTE(call COMPILE_SCRIPT(XEH_postInitClient));
-        serverInit = QUOTE(call COMPILE_SCRIPT(XEH_postInitServer));
+        init = QUOTE(call COMPILE_SCRIPT(XEH_postInit));
     };
 };
 

--- a/addons/jammers/XEH_postInit.sqf
+++ b/addons/jammers/XEH_postInit.sqf
@@ -1,0 +1,12 @@
+#include "script_component.hpp"
+
+// Tracked separately on server and client
+GVAR(activeJammers) = createHashmap;
+
+if (isServer) then {
+    call COMPILE_SCRIPT(XEH_postInitServer)
+};
+
+if (hasInterface) then {
+    call COMPILE_SCRIPT(XEH_postInitClient)
+};

--- a/addons/jammers/XEH_postInitClient.sqf
+++ b/addons/jammers/XEH_postInitClient.sqf
@@ -1,6 +1,5 @@
 #include "script_component.hpp"
 
-GVAR(activeJammers) = createHashmap;
 GVAR(jammerHandlerClient) = -1;
 GVAR(interferenceFactor) = 0.625;
 

--- a/addons/jammers/XEH_postInitClient.sqf
+++ b/addons/jammers/XEH_postInitClient.sqf
@@ -7,7 +7,7 @@ GVAR(interferenceFactor) = 0.625;
     [QGVAR(addJammerLocal), {
         params ["_hash", "_jammer", "_radius", "_strength"];
         TRACE_4("addJammerLocal",_hash,_jammer,_radius,_strength);
-        if (isServer) exitWith {}; // For singleplayer
+
         GVAR(activeJammers) set [_hash, [_jammer, _radius, _strength]];
 
         if (GVAR(jammerHandlerClient) < 0) then {
@@ -18,7 +18,7 @@ GVAR(interferenceFactor) = 0.625;
     [QGVAR(removeJammerLocal), {
         params ["_hash"];
         TRACE_1("removeJammerLocal",_hash);
-        if (isServer) exitWith {};
+
         GVAR(activeJammers) deleteAt _hash;
     }] call CBA_fnc_addEventHandler;
 }] call CBA_fnc_addEventHandler;

--- a/addons/jammers/XEH_postInitServer.sqf
+++ b/addons/jammers/XEH_postInitServer.sqf
@@ -1,6 +1,5 @@
 #include "script_component.hpp"
 
-GVAR(activeJammers) = createHashmap;
 GVAR(jammerHandlerServer) = -1;
 
 ["CBA_settingsInitialized", {

--- a/addons/jetpacks/CfgEventHandlers.hpp
+++ b/addons/jetpacks/CfgEventHandlers.hpp
@@ -13,7 +13,6 @@ class Extended_PreInit_EventHandlers {
 class Extended_PostInit_EventHandlers {
     class ADDON {
         init = QUOTE(call COMPILE_SCRIPT(XEH_postInit));
-        clientInit = QUOTE(call COMPILE_SCRIPT(XEH_postInitClient));
     };
 };
 

--- a/addons/jetpacks/XEH_postInit.sqf
+++ b/addons/jetpacks/XEH_postInit.sqf
@@ -3,3 +3,7 @@
 ["CBA_settingsInitialized", {
     ["BNA_KC_Jet_JetpackFired", {_this call BNA_KC_Jetpacks_fnc_effectHandler}] call CBA_fnc_addEventHandler;
 }] call CBA_fnc_addEventHandler;
+
+if (hasInterface) then {
+    call COMPILE_SCRIPT(XEH_postInitClient)
+};

--- a/addons/medical/CfgEventHandlers.hpp
+++ b/addons/medical/CfgEventHandlers.hpp
@@ -12,8 +12,7 @@ class Extended_PreInit_EventHandlers {
 
 class Extended_PostInit_EventHandlers {
     class ADDON {
-        clientInit = QUOTE(call COMPILE_SCRIPT(XEH_postInitClient));
-        serverInit = QUOTE(call COMPILE_SCRIPT(XEH_postInitServer));
+        init = QUOTE(call COMPILE_SCRIPT(XEH_postInit));
     };
 };
 

--- a/addons/medical/XEH_postInit.sqf
+++ b/addons/medical/XEH_postInit.sqf
@@ -1,0 +1,9 @@
+#include "script_component.hpp"
+
+if (isServer) then {
+    call COMPILE_SCRIPT(XEH_postInitServer)
+};
+
+if (hasInterface) then {
+    call COMPILE_SCRIPT(XEH_postInitClient)
+};

--- a/addons/memes/CfgEventHandlers.hpp
+++ b/addons/memes/CfgEventHandlers.hpp
@@ -12,6 +12,6 @@ class Extended_PreInit_EventHandlers {
 
 class Extended_PostInit_EventHandlers {
     class ADDON {
-        clientInit = QUOTE(call COMPILE_SCRIPT(XEH_postInitClient));
+        init = QUOTE(call COMPILE_SCRIPT(XEH_postInit));
     };
 };

--- a/addons/memes/XEH_postInit.sqf
+++ b/addons/memes/XEH_postInit.sqf
@@ -1,0 +1,5 @@
+#include "script_component.hpp"
+
+if (hasInterface) then {
+    call COMPILE_SCRIPT(XEH_postInitClient)
+};

--- a/addons/vehicles/CfgEventHandlers.hpp
+++ b/addons/vehicles/CfgEventHandlers.hpp
@@ -12,7 +12,7 @@ class Extended_PreInit_EventHandlers {
 
 class Extended_PostInit_EventHandlers {
     class ADDON {
-        serverInit = QUOTE(call COMPILE_SCRIPT(XEH_postInitServer));
+        init = QUOTE(call COMPILE_SCRIPT(XEH_postInit));
     };
 };
 

--- a/addons/vehicles/XEH_postInit.sqf
+++ b/addons/vehicles/XEH_postInit.sqf
@@ -1,0 +1,5 @@
+#include "script_component.hpp"
+
+if (isServer) then {
+    call COMPILE_SCRIPT(XEH_postInitServer)
+};


### PR DESCRIPTION
## Description
Updated all relevant addons to use a single `XEH_postInit` script in `Extended_PostInit_EventHandlers`. There is not a specified order that `init`, `serverInit`, or `clientInit` run in, and they are only kept for backwards compatibility. Instead, only a single `init` script is included, which then always runs server and then client code.

Here's an example from the Jammers addon.
```cpp
// CfgEventHandlers.hpp
class Extended_PostInit_EventHandlers {
    class ADDON {
        init = QUOTE(call COMPILE_SCRIPT(XEH_postInit));
    };
};
```
```sqf
// XEH_postInit.sqf
#include "script_component.hpp"

// Tracked separately on server and client
GVAR(activeJammers) = createHashmap;

if (isServer) then {
    call COMPILE_SCRIPT(XEH_postInitServer)
};

if (hasInterface) then {
    call COMPILE_SCRIPT(XEH_postInitClient)
};
```

<!--
If multiple components are being modified, add **Component Name** to the beginning of each list.
e.g.
**Core**
- Change 1

**Weapons**
- Change 1
-->
## Changes
- All addons use a single `XEH_postInit` script
- Removed `isServer` checks from `addJammerLocal` / `removeJammerLocal`, as they are not needed.