### PR TITLE
Armor - Remove pauldron from heavy vests.

### DIFF
--- a/addons/armor/configs/Vests_Infantry.hpp
+++ b/addons/armor/configs/Vests_Infantry.hpp
@@ -57,7 +57,7 @@ class CLASS(Vest_Heavy): CLASS(Vest_Basic) {
         QPATHTOF(data\vests\infantry\heavy\Accessories_camo1_co.paa), // Sling and Bag
         QPATHTOF(data\vests\infantry\heavy\Accessories_camo1_co.paa), // Holster
         "\SWLB_clones\data\light_accessories_co.paa",                 // Grenades
-        QPATHTOF(data\vests\infantry\heavy\Accessories_camo1_co.paa), // Pauldron
+        ""                                                            // Pauldron
     };
     picture = "\SWLB_clones\data\ui\icon_SWLB_clone_airborne_nco_armor_ca.paa";
 
@@ -79,7 +79,7 @@ class CLASS(Vest_Heavy_v2): CLASS(Vest_Heavy) {
         QPATHTOF(data\vests\infantry\heavy\Accessories_camo1_co.paa),           // Holster
         "\SWLB_core\data\common_textures\equipment\bag_co.paa",                 // Belt Bag
         "\SWLB_core\data\common_textures\accessories\light_accessories_co.paa", // Back Grenade
-        QPATHTOF(data\vests\infantry\heavy\Accessories_camo1_co.paa)            // Pauldron
+        ""                                                                      // Pauldron
     };
     picture = "\SWLB_clones\data\ui\icon_SWLB_clone_recon_nco_armor_ca.paa";
 


### PR DESCRIPTION
## Description
Removes the pauldron from both variants of the heavy gunner vests.

<!--
If multiple components are being modified, add **Component Name** to the beginning of each list.
e.g.
**Core**
- Change 1

**Weapons**
- Change 1
-->
## Changes
- Removed pauldrons from heavy gunner vests.