### PR TITLE
Weapons - Fix RPS-6 not saving in arsenal

### DIFF
--- a/addons/weapons/rps6/CfgWeapons.hpp
+++ b/addons/weapons/rps6/CfgWeapons.hpp
@@ -9,7 +9,7 @@ class CfgWeapons {
         author = AUTHOR;
 
         displayName = "[KC] RPS-6 (Base)";
-        baseWeapon = QCLASS(RPS6_Disposable);
+        baseWeapon = QCLASS(RPS6_Base);
 
         modes[] = {"Single"};
         muzzles[] = {"this"};
@@ -37,7 +37,7 @@ class CfgWeapons {
         SCOPE_HIDDEN;
         displayName = "[KC] RPS-6";
         descriptionShort = "Single-use Rocket Tube";
-        // baseWeapon = QCLASS(RPS6_Disposable);
+        baseWeapon = QCLASS(RPS6_Disposable);
 
         magazineReloadTime = 0.1;
 
@@ -52,7 +52,6 @@ class CfgWeapons {
     class CLASS(RPS6_Loaded): CLASS(RPS6_Disposable) {
         SCOPE_PUBLIC;
 
-        // baseWeapon = QCLASS(RPS6_Loaded);
         magazines[] = {"CBA_FakeLauncherMagazine"};
 
         class WeaponSlotsInfo: WeaponSlotsInfo {
@@ -65,8 +64,6 @@ class CfgWeapons {
 
         displayName = "[KC] RPS-6 (Used)";
         descriptionShort = "Used Rocket Tube";
-        // baseWeapon = QCLASS(RPS6_Used);
-
         magazines[] = {"CBA_FakeLauncherMagazine"};
 
         JLTS_hasEMPProtection = TRUE; // No point in making a fried version
@@ -77,7 +74,6 @@ class CfgWeapons {
         displayName = "[KC] RPS-6 (Fried)";
         descriptionShort = "The circuits of the weapon have<br/>been fried by an EMP blast.";
         picture = QPATHTOF(rps6\data\ui\RPS6_Fried_ca.paa);
-        // baseWeapon = QCLASS(RPS6_Disposable_Fried);
 
         JLTS_isFried = TRUE;
         JLTS_baseWeapon = QCLASS(RPS6_Disposable);

--- a/addons/weapons/rps6/CfgWeapons.hpp
+++ b/addons/weapons/rps6/CfgWeapons.hpp
@@ -9,7 +9,7 @@ class CfgWeapons {
         author = AUTHOR;
 
         displayName = "[KC] RPS-6 (Base)";
-        baseWeapon = QCLASS(RPS6_Base);
+        baseWeapon = QCLASS(RPS6_Disposable);
 
         modes[] = {"Single"};
         muzzles[] = {"this"};
@@ -37,7 +37,7 @@ class CfgWeapons {
         SCOPE_HIDDEN;
         displayName = "[KC] RPS-6";
         descriptionShort = "Single-use Rocket Tube";
-        baseWeapon = QCLASS(RPS6_Disposable);
+        // baseWeapon = QCLASS(RPS6_Disposable);
 
         magazineReloadTime = 0.1;
 
@@ -52,7 +52,7 @@ class CfgWeapons {
     class CLASS(RPS6_Loaded): CLASS(RPS6_Disposable) {
         SCOPE_PUBLIC;
 
-        baseWeapon = QCLASS(RPS6_Loaded);
+        // baseWeapon = QCLASS(RPS6_Loaded);
         magazines[] = {"CBA_FakeLauncherMagazine"};
 
         class WeaponSlotsInfo: WeaponSlotsInfo {
@@ -65,7 +65,7 @@ class CfgWeapons {
 
         displayName = "[KC] RPS-6 (Used)";
         descriptionShort = "Used Rocket Tube";
-        baseWeapon = QCLASS(RPS6_Used);
+        // baseWeapon = QCLASS(RPS6_Used);
 
         magazines[] = {"CBA_FakeLauncherMagazine"};
 
@@ -77,7 +77,7 @@ class CfgWeapons {
         displayName = "[KC] RPS-6 (Fried)";
         descriptionShort = "The circuits of the weapon have<br/>been fried by an EMP blast.";
         picture = QPATHTOF(rps6\data\ui\RPS6_Fried_ca.paa);
-        baseWeapon = QCLASS(RPS6_Disposable_Fried);
+        // baseWeapon = QCLASS(RPS6_Disposable_Fried);
 
         JLTS_isFried = TRUE;
         JLTS_baseWeapon = QCLASS(RPS6_Disposable);


### PR DESCRIPTION
## Description
Fix the RPS-6 not being saved in loadouts.

<!--
If multiple components are being modified, add **Component Name** to the beginning of each list.
e.g.
**Core**
- Change 1

**Weapons**
- Change 1
-->
## Changes
- Made disposable, loaded, and used versions of the RPS-6 all use the same `baseWeapon`.