### PR TITLE
Weapons - Fix fried picture for DC-20Y

### DIFF
--- a/addons/weapons/dc20y/CfgWeapons.hpp
+++ b/addons/weapons/dc20y/CfgWeapons.hpp
@@ -60,7 +60,7 @@ class CfgWeapons {
         SCOPE_HIDDEN;
         displayName = "[KC] DC-20Y (Fried)";
         descriptionShort = "The circuits of the weapon have<br/>been fried by an EMP blast.";
-        picture = QPATHTOF(dc20y\data\ui\DC20Y_Fried_ui_ca.paa);
+        picture = QPATHTOF(dc20y\data\ui\DC20Y_Fried_ca.paa);
         baseWeapon = QCLASS(DC20Y_Fried);
 
         JLTS_isFried = TRUE;


### PR DESCRIPTION
## Description
Fixed typo in file name.

<!--
If multiple components are being modified, add **Component Name** to the beginning of each list.
e.g.
**Core**
- Change 1

**Weapons**
- Change 1
-->
## Changes
- Fixed file name from `DC20Y_Fried_ui_ca.paa` to `DC20Y_Fried_ca.paa`