### PR TITLE
Armor - Added external intercom to crewmen helmets

### DIFF
--- a/addons/armor/configs/Helmets_P1_Pilot.hpp
+++ b/addons/armor/configs/Helmets_P1_Pilot.hpp
@@ -13,6 +13,7 @@ class CLASS(Helmet_Phase1_Pilot_Base): CLASS(Helmet_Base) {
     picture = "\ls_armor_bluefor\helmet\_ui\icon_gar_phase1_helmet_ca.paa";
 
     HEARING_PROTECTION_CREW;
+    TFAR_externalIntercomWirelessCapable = TRUE;
 
     class ItemInfo: ItemInfo {
         hiddenSelections[] = {"camo1", "camo2", "visor"};

--- a/addons/armor/configs/Helmets_P1_SpecOp.hpp
+++ b/addons/armor/configs/Helmets_P1_SpecOp.hpp
@@ -13,6 +13,7 @@ class CLASS(Helmet_Phase1_Tanker_Base): CLASS(Helmet_Base) {
     subItems[] = {QCLASS(NVG_Chip)};
 
     HEARING_PROTECTION_CREW;
+    TFAR_externalIntercomWirelessCapable = TRUE;
 
     class ItemInfo: ItemInfo {
         hiddenSelections[] = {"Camo1", "visor"};

--- a/addons/armor/configs/Helmets_P2_Pilot.hpp
+++ b/addons/armor/configs/Helmets_P2_Pilot.hpp
@@ -12,6 +12,7 @@ class CLASS(Helmet_Phase2_Pilot_Base): CLASS(Helmet_Base) {
     picture = "\SWLB_clones\data\ui\icon_SWLB_clone_pilot_P2_helmet_ca.paa";
 
     HEARING_PROTECTION_CREW;
+    TFAR_externalIntercomWirelessCapable = TRUE;
 
     class ItemInfo: ItemInfo {
         hiddenSelections[] = {"camo1", "visor"};

--- a/addons/armor/configs/Helmets_P2_SpecOp.hpp
+++ b/addons/armor/configs/Helmets_P2_SpecOp.hpp
@@ -13,6 +13,7 @@ class CLASS(Helmet_Phase2_Tanker_Base): CLASS(Helmet_Base) {
     subItems[] = {QCLASS(NVG_Chip)};
 
     HEARING_PROTECTION_CREW;
+    TFAR_externalIntercomWirelessCapable = TRUE;
 
     class ItemInfo: ItemInfo {
         hiddenSelections[] = {"Camo1", "visor"};


### PR DESCRIPTION
## Description
Added ability for crewmen helmets to connect to vehicle intercoms.

<!--
If multiple components are being modified, add **Component Name** to the beginning of each list.
e.g.
**Core**
- Change 1

**Weapons**
- Change 1
-->
## Changes
- Set `TFAR_externalIntercomWirelessCapable` to 1 on crewmen helmets.