### PR TITLE
CIS - Fixed missing droid uniforms in XtdGearModels

### DIFF
--- a/addons/factions/cis/XtdGearModels.hpp
+++ b/addons/factions/cis/XtdGearModels.hpp
@@ -15,7 +15,9 @@ class XtdGearModels {
                     "Commander",
                     "Crew",
                     "Pilot",
-                    "Rocket"
+                    "Engineer",
+                    "Rocket",
+                    "Prototype"
                 };
 
                 class Standard { label = "Standard"; };
@@ -24,7 +26,9 @@ class XtdGearModels {
                 class Commander { label = "Commander"; };
                 class Crew { label = "Crew"; };
                 class Pilot { label = "Pilot"; };
+                class Engineer { label = "Engineer"; };
                 class Rocket { label = "Rocket"; };
+                class Prototype { label = "Prototype"; };
             };
 
             class variant {


### PR DESCRIPTION
## Description
Fixed missing uniforms from ACE Arsenal Extended.

<!--
If multiple components are being modified, add **Component Name** to the beginning of each list.
e.g.
**Core**
- Change 1

**Weapons**
- Change 1
-->
## Changes
- Added Engineer uniform to XtdGearModels
- Added Prototype uniform to XtdGearModels