### PR TITLE
Jetpacks - CDV-21 can no longer hover

### DIFF
--- a/addons/jetpacks/CfgVehicles.hpp
+++ b/addons/jetpacks/CfgVehicles.hpp
@@ -46,6 +46,7 @@ class CfgVehicles {
         GVAR(fuel) = JETPACK_FUEL_DEFAULT;
         GVAR(speed) = JETPACK_SPEED_DEFAULT;     // Jetpack speed, effects how fast you move in the air
         GVAR(strength) = JETPACK_STRENGTH_DEFAULT; // Jetpack strength, effects fast the player rises
+        GVAR(canHover) = TRUE;
 
         // Effects
         GVAR(effectPoints)[] = {"effect_left", "effect_right"}; // Points to spawn effects, these come from the JLTS model
@@ -61,6 +62,7 @@ class CfgVehicles {
 
     class CLASS(Jetpack_CDV21): CLASS(Jetpack_JT12) {
         GVAR(strength) = 0;
+        GVAR(canHover) = FALSE;
     };
 
     class CLASS(Jetpack_CDV19): CLASS(Jetpack_JT12) {
@@ -75,6 +77,7 @@ class CfgVehicles {
         GVAR(fuel) = JETPACK_FUEL_DEFAULT;
         GVAR(speed) = JETPACK_SPEED_DEFAULT;
         GVAR(strength) = JETPACK_STRENGTH_DEFAULT;
+        GVAR(canHover) = TRUE;
 
         GVAR(effectPoints)[] = {"effect_left", "effect_right"};
         GVAR(effects)[] = {

--- a/addons/jetpacks/initKeybinds.inc.sqf
+++ b/addons/jetpacks/initKeybinds.inc.sqf
@@ -47,6 +47,7 @@
     QGVAR(key_toggleHover),
     ["Toggle Hover", "Puts the user into a hover state. Only activates if not touching the ground."],
     {
+        if (getNumber (configOf backpackContainer ace_player >> QGVAR(canHover)) <= FALSE) exitWith {};
         if !(isTouchingGround ace_player) then {
             _hoverState = !(ace_player getVariable ["BNA_KC_Jet_hover", false]);
             ace_player setVariable ["BNA_KC_Jet_hover", _hoverState];


### PR DESCRIPTION
## Description
The CDV-21 Droppack is no longer able to hover.

<!--
If multiple components are being modified, add **Component Name** to the beginning of each list.
e.g.
**Core**
- Change 1

**Weapons**
- Change 1
-->
## Changes
- The CDV-21 Droppack is no longer able to hover