### PR TITLE
CIS - Fixed droid uniforms/backpacks for ACE Arsenal Extended

### DIFF
--- a/addons/factions/cis/CfgWeapons.hpp
+++ b/addons/factions/cis/CfgWeapons.hpp
@@ -113,7 +113,7 @@ class CfgWeapons {
 
         class XtdGearInfo {
             model = QCLASS(CIS_Uniforms_BX);
-            role = "Standard";
+            type = "Standard";
         };
     };
 

--- a/addons/factions/cis/CfgWeapons.hpp
+++ b/addons/factions/cis/CfgWeapons.hpp
@@ -33,7 +33,7 @@ class CfgWeapons {
 
         class XtdGearInfo {
             model = QCLASS(CIS_Uniforms_B1);
-            camo = "Standard";
+            type = "Standard";
             variant = "Standard";
         };
     };
@@ -47,36 +47,28 @@ class CfgWeapons {
     B1_UNIFORM(Rocket);
     B1_UNIFORM(Prototype);
 
-    class CLASS(CIS_Uniform_Droid_B1_Geonosis): CLASS(CIS_Uniform_Droid_Base) {
-        SCOPE_PUBLIC;
-
+    class CLASS(CIS_Uniform_Droid_B1_Geonosis): CLASS(CIS_Uniform_Droid_B1) {
         displayName = "[CIS] B1 Battle Droid (Geonosis)";
 
         class ItemInfo: ItemInfo {
             uniformClass = QCLASS(CIS_Unit_Droid_B1_Geonosis);
         };
 
-        class XtdGearInfo {
-            model = QCLASS(CIS_Uniforms_B1);
-            camo = "Standard";
+        class XtdGearInfo: XtdGearInfo {
             variant = "Geonosis";
         };
     };
 
     B1_VARIANT_UNIFORM(Commander,Geonosis);
 
-    class CLASS(CIS_Uniform_Droid_B1_Training): CLASS(CIS_Uniform_Droid_Base) {
-        SCOPE_PUBLIC;
-
+    class CLASS(CIS_Uniform_Droid_B1_Training): CLASS(CIS_Uniform_Droid_B1) {
         displayName = "[CIS] B1 Battle Droid (Training)";
 
         class ItemInfo: ItemInfo {
             uniformClass = QCLASS(CIS_Unit_Droid_B1_Training);
         };
 
-        class XtdGearInfo {
-            model = QCLASS(CIS_Uniforms_B1);
-            camo = "Standard";
+        class XtdGearInfo: XtdGearInfo {
             variant = "Training";
         };
     };
@@ -92,7 +84,7 @@ class CfgWeapons {
 
         class XtdGearInfo {
             model = QCLASS(CIS_Uniforms_B2);
-            camo = "Standard";
+            type = "Standard";
         };
     };
 
@@ -106,7 +98,7 @@ class CfgWeapons {
         };
 
         class XtdGearInfo: XtdGearInfo {
-            camo = "Jetpack";
+            type = "Jetpack";
         };
     };
 

--- a/addons/factions/cis/XtdGearModels.hpp
+++ b/addons/factions/cis/XtdGearModels.hpp
@@ -77,10 +77,10 @@ class XtdGearModels {
         class CLASS(CIS_Uniforms_BX) {
             label = "BX Commando Droid";
             author = AUTHOR;
-            options[] = {"role"};
+            options[] = {"type"};
 
-            class role {
-                label = "Role";
+            class type {
+                label = "Type";
                 changeInGame = FALSE;
                 values[] = {
                     "Standard",

--- a/addons/factions/cis/XtdGearModels.hpp
+++ b/addons/factions/cis/XtdGearModels.hpp
@@ -3,11 +3,12 @@ class XtdGearModels {
         class CLASS(CIS_Uniforms_B1) {
             label = "B1 Battle Droid";
             author = AUTHOR;
-            options[] = {"camo", "variant"};
+            options[] = {"type", "variant"};
 
-            class camo {
-                label = "Role";
+            class type {
+                label = "Type";
                 changeInGame = FALSE;
+                alwaysSelectable = TRUE;
                 values[] = {
                     "Standard",
                     "Marine",
@@ -58,10 +59,10 @@ class XtdGearModels {
         class CLASS(CIS_Uniforms_B2) {
             label = "B2 Super Battle Droid";
             author = AUTHOR;
-            options[] = {"camo"};
+            options[] = {"type"};
 
-            class camo {
-                label = "Role";
+            class type {
+                label = "Type";
                 changeInGame = FALSE;
                 values[] = {
                     "Standard",
@@ -102,19 +103,22 @@ class XtdGearModels {
         class CLASS(CIS_Backpacks_B1) {
             label = "B1 Battle Droid";
             author = AUTHOR;
-            options[] = {"camo", "variant"};
+            options[] = {"type", "variant"};
 
-            class camo {
+            class type {
                 label = "Type";
                 changeInGame = FALSE;
+                alwaysSelectable = TRUE;
                 values[] = {
                     "Standard",
+                    "Engineer",
                     "Saboteur",
                     "Prototype",
                     "Antenna"
                 };
 
                 class Standard { label = "Standard"; };
+                class Engineer { label = "Engineer"; };
                 class Saboteur { label = "Saboteur"; };
                 class Prototype { label = "Prototype"; };
                 class Antenna { label = "Antenna"; };
@@ -141,6 +145,23 @@ class XtdGearModels {
                     label = "Training";
                     image = "#(rgb,8,8,3)color(0.561,0.561,0.561,1)";
                 };
+            };
+        };
+
+        class CLASS(CIS_Jetpacks): CLASS(CIS_Backpacks_B1) {
+            label = "B1 Jetpacks";
+            options[] = {"type"};
+
+            class type {
+                label = "Type";
+                changeInGame = FALSE;
+                values[] = {
+                    "Standard",
+                    "Rocket"
+                };
+
+                class Standard { label = "Standard"; };
+                class Rocket { label = "Rocket"; };
             };
         };
     };

--- a/addons/factions/cis/configs/Backpacks.hpp
+++ b/addons/factions/cis/configs/Backpacks.hpp
@@ -18,7 +18,7 @@ class CLASS(CIS_Backpack_Droid_B1): CLASS(backpack_base) {
 
     class XtdGearInfo {
         model = QCLASS(CIS_Backpacks_B1);
-        camo = "Standard";
+        type = "Standard";
         variant = "Standard";
     };
 };
@@ -49,7 +49,7 @@ class CLASS(CIS_Backpack_Droid_B1_Engineer): CLASS(CIS_Backpack_Droid_B1) {
     hiddenSelectionsTextures[] = {QPATHTOF(cis\data\textures\backpacks\B1_Engineer_co.paa)};
 
     class XtdGearInfo: XtdGearInfo {
-        camo = "Engineer";
+        type = "Engineer";
     };
 };
 
@@ -58,7 +58,7 @@ class CLASS(CIS_Backpack_Droid_B1_Saboteur): CLASS(CIS_Backpack_Droid_B1) {
     hiddenSelectionsTextures[] = {QPATHTOF(cis\data\textures\backpacks\B1_Saboteur_co.paa)};
 
     class XtdGearInfo: XtdGearInfo {
-        camo = "Saboteur";
+        type = "Saboteur";
     };
 };
 
@@ -67,7 +67,7 @@ class CLASS(CIS_Backpack_Droid_B1_Prototype): CLASS(CIS_Backpack_Droid_B1) {
     hiddenSelectionsTextures[] = {"\MRC\JLTS\characters\DroidArmor\data\b1_backpack_prototype_co.paa"};
 
     class XtdGearInfo: XtdGearInfo {
-        camo = "Prototype";
+        type = "Prototype";
     };
 };
 
@@ -112,7 +112,7 @@ class CLASS(CIS_Backpack_Droid_B1_Antenna): CLASS(CIS_Backpack_Droid_B1) {
     picture = "\MRC\JLTS\characters\DroidArmor\data\ui\b1_antenna_ui_ca.paa";
 
     class XtdGearInfo: XtdGearInfo {
-        camo = "Antenna";
+        type = "Antenna";
         variant = "Standard";
     };
 };
@@ -160,9 +160,18 @@ class CLASS(CIS_Jetpack_Droid_B1): CLASS(CIS_Backpack_Droid_B1) {
         "JLTS_jumppack_error",
         "JLTS_SFX_jumppack_idle"
     };
+
+    class XtdGearInfo {
+        model = QCLASS(CIS_Jetpacks);
+        type = "Standard";
+    };
 };
 
 class CLASS(CIS_Jetpack_Droid_B1_Rocket): CLASS(CIS_Jetpack_Droid_B1) {
     displayName = "[KC] Battle Droid Jetpack (Rocket)";
     hiddenSelectionsTextures[] = {"\MRC\JLTS\characters\DroidArmor\data\b1_jetpack_rocket_co.paa"};
+
+    class XtdGearInfo: XtdGearInfo {
+        type = "Rocket";
+    };
 };

--- a/addons/factions/cis/script_macros.hpp
+++ b/addons/factions/cis/script_macros.hpp
@@ -28,6 +28,6 @@
         uniformClass = QCLASS(DOUBLES(CIS_Unit_Droid_BX,var1)); \
     }; \
     class XtdGearInfo: XtdGearInfo { \
-        role = QUOTE(var1); \
+        type = QUOTE(var1); \
     }; \
 }

--- a/addons/factions/cis/script_macros.hpp
+++ b/addons/factions/cis/script_macros.hpp
@@ -1,27 +1,22 @@
 #define DROID_LINKED_ITEMS "SWLB_Comlink_Droid"
 
-#define B1_UNIFORM(var1) class CLASS(DOUBLES(CIS_Uniform_Droid_B1,var1)): CLASS(CIS_Uniform_Droid_Base) { \
-    SCOPE_PUBLIC; \
+#define B1_UNIFORM(var1) class CLASS(DOUBLES(CIS_Uniform_Droid_B1,var1)): CLASS(CIS_Uniform_Droid_B1) { \
     displayName = QUOTE([CIS] B1 var1 Droid); \
     class ItemInfo: ItemInfo { \
         uniformClass = QCLASS(DOUBLES(CIS_Unit_Droid_B1,var1)); \
     }; \
-    class XtdGearInfo { \
-        model = QCLASS(CIS_Uniforms_B1); \
-        camo = QUOTE(var1); \
-        variant = "Standard"; \
+    class XtdGearInfo: XtdGearInfo { \
+        type = QUOTE(var1); \
     }; \
 }
 
-#define B1_VARIANT_UNIFORM(var1,var2) class CLASS(TRIPLES(CIS_Uniform_Droid_B1,var1,var2)): CLASS(CIS_Uniform_Droid_Base) { \
-    SCOPE_PUBLIC; \
+#define B1_VARIANT_UNIFORM(var1,var2) class CLASS(TRIPLES(CIS_Uniform_Droid_B1,var1,var2)): CLASS(CIS_Uniform_Droid_B1) { \
     displayName = QUOTE([CIS] B1 var1 Droid (var2)); \
     class ItemInfo: ItemInfo { \
         uniformClass = QCLASS(TRIPLES(CIS_Unit_Droid_B1,var1,var2)); \
     }; \
-    class XtdGearInfo { \
-        model = QCLASS(CIS_Uniforms_B1); \
-        camo = QUOTE(var1); \
+    class XtdGearInfo: XtdGearInfo { \
+        type = QUOTE(var1); \
         variant = QUOTE(var2); \
     }; \
 }


### PR DESCRIPTION
## Description
Fixed missing droid uniforms and backpacks in ACE Arsenal Extended.

<!--
If multiple components are being modified, add **Component Name** to the beginning of each list.
e.g.
**Core**
- Change 1

**Weapons**
- Change 1
-->
## Changes
- Renamed `camo`/`role` to `type`
- Fixed missing droid engineer backpack
- Fixed missing droid jetpacks
- Updated inheritance for B1 uniforms
    - All B1 uniforms inherit from standard B1 uniform