### PR TITLE
Tools - Updated hemtt presets to use "extends"

### DIFF
--- a/.hemtt/project.toml
+++ b/.hemtt/project.toml
@@ -39,43 +39,17 @@ mission = "AuxTest.VR"
 parameters = []
 
 [hemtt.launch.full]
+extends = "default"
 workshop = [
-    "2369477168", # ADT
-    "623475643",  # 3DEN
-    "1779063631", # ZEN
-    "2018593688", # ZEN ACE Compat
-    "1686872930", # SDT
-    "2567352444", # WBK Droids # TODO: Move assets to aux itself
-    "2522638637", # ACE Arsenal Extended
     "1572627279", # OPTRE First Contact
     "2915485125", # Burn 'Em
-    "767380317",  # Blastcore
     "2789152015", # WBK Zombies
     "2478080991", # Scion Conflict
 ]
-presets = ["main"]
-dlc = []
 optionals = ["no_burn_screams"]
-mission = "AuxTest.VR"
-parameters = []
 
 [hemtt.launch.previews]
-workshop = [
-    "2369477168", # ADT
-    "623475643",  # 3DEN
-    "1779063631", # ZEN
-    "2018593688", # ZEN ACE Compat
-    "1686872930", # SDT
-    "2567352444", # WBK Droids # TODO: Move assets to aux
-    "1572627279", # OPTRE First Contact
-    "2915485125", # Burn 'Em
-    "767380317",  # Blastcore
-    "2789152015", # WBK Zombies
-    "2478080991", # Scion Conflict
-]
-presets = ["main"]
-dlc = []
-optionals = []
+extends = "full"
 parameters = [
     "C:\\Users\\skull\\OneDrive\\Documents\\Arma 3 - Other Profiles\\Previews\\missions\\Previews.VR\\mission.sqm",
     "-name=Previews",


### PR DESCRIPTION
## Description
Updated launch presets to use new HEMTT `extends` key.

<!--
If multiple components are being modified, add **Component Name** to the beginning of each list.
e.g.
**Core**
- Change 1

**Weapons**
- Change 1
-->
## Changes
- Simplified `full` and `previews` presets
- Removed duplicate entry for Schlabbie's Depressed Textures