### PR TITLE
Tools - Reset build version on release

### DIFF
--- a/.hemtt/scripts/update_minor.rhai
+++ b/.hemtt/scripts/update_minor.rhai
@@ -11,6 +11,7 @@ let current = HEMTT.project().version().minor();
 let next = current + 1;
 
 script_version.replace(prefix + current.to_string(), prefix + next.to_string());
+script_version.replace("#define PATCH " + current.to_string(), "#define PATCH 0");
 script_version.replace("#define BUILD " + current.to_string(), "#define BUILD 0");
 
 // Write the modified contents to script_version.hpp


### PR DESCRIPTION
## Description
Reset `BUILD` version on release.

<!--
If multiple components are being modified, add **Component Name** to the beginning of each list.
e.g.
**Core**
- Change 1

**Weapons**
- Change 1
-->
## Changes
- `BUILD` version is reset on release