### PR TITLE
Vehicles - Rho/Nu tweaks

### DIFF
--- a/addons/core/XEH_PREP.hpp
+++ b/addons/core/XEH_PREP.hpp
@@ -2,6 +2,7 @@ PREP(getNearbyUnits);
 PREP(inFeatureCamera);
 PREP(isEngineer);
 PREP(isMedic);
+PREP(isVehicleCrew);
 PREP(loopSay3D_init);
 PREP(loopSay3D);
 PREP(playLocalSound);

--- a/addons/core/functions/fnc_isVehicleCrew.sqf
+++ b/addons/core/functions/fnc_isVehicleCrew.sqf
@@ -1,0 +1,35 @@
+#include "..\script_component.hpp"
+/*
+ * Author: DartRuffian
+ * Determines if a given unit is a crew member.
+ *
+ * Arguments:
+ * 0: Unit to check (Optional, default: ace_player) <OBJECT>
+ * 1: Seat types to include (Optional, default: ["driver", "commander", "gunner", "turret"]) <ARRAY>
+ *    - Can be an array including any of: driver, commander, gunner, turret, cargo, ffv
+ * 2: The vehicle (Optional, default: objectParent of _unit) <OBJECT>
+ *
+ * Return Value:
+ * True if unit is in specified seat type, otherwise false <BOOL>
+ *
+ * Examples:
+ * (objectParent ace_player) call BNA_KC_core_fnc_isVehicleCrew;
+ *
+ * Public: Yes
+ */
+
+params [
+    ["_unit", ace_player, [objNull]],
+    ["_types", ["driver", "commander", "gunner", "turret"], [[]]],
+    ["_vehicle", objNull, [objNull]]
+];
+private ["_crew"];
+TRACE_3("fnc_isVehicleCrew",_unit,_types,_vehicle);
+
+if (isNull _unit or {_types isEqualTo []}) exitWith {};
+if (isNull _vehicle) then {
+    _vehicle = objectParent _unit;
+};
+
+_crew = [_vehicle, _types] call ace_common_fnc_getVehicleCrew;
+_unit in _crew;

--- a/addons/core/script_macros.hpp
+++ b/addons/core/script_macros.hpp
@@ -104,6 +104,11 @@ scopeCurator = 0
     count = COUNT; \
 }
 
+#define CARGO_XX(ITEM, COUNT) class ITEM { \
+    type = QUOTE(ITEM); \
+    amount = COUNT; \
+}
+
 #define GROUND_CLASS(WEAP_NAME) DOUBLES(Ground,CLASS(WEAP_NAME))
 #define QGROUND_CLASS(WEAP_NAME) QUOTE(GROUND_CLASS(WEAP_NAME))
 #define GROUND_HOLDER(WEAP_NAME, DISPLAY_NAME) class GROUND_CLASS(WEAP_NAME): GROUND_CLASS(Holder_Base) { \

--- a/addons/vehicles/XEH_PREP.hpp
+++ b/addons/vehicles/XEH_PREP.hpp
@@ -10,6 +10,7 @@ PREP(atrt_skin_insertChildren);
 PREP(autoEject);
 PREP(canDeleteCrew);
 PREP(canEjectUnit);
+PREP(canImpulse);
 PREP(canSpawnCrew);
 PREP(csw_canDeploy);
 PREP(csw_canPickup);

--- a/addons/vehicles/air/laatc/CfgVehicles.hpp
+++ b/addons/vehicles/air/laatc/CfgVehicles.hpp
@@ -21,12 +21,7 @@ class CfgVehicles {
         crew = QCLASS(Unit_Phase2_CXA);
         typicalCargo[] = {QCLASS(Unit_Phase2_CXA)};
 
-        ls_impulsor_soundOn = QCLASS(Sound_ImpulseOn);
-        ls_impulsor_soundOff = QCLASS(Sound_ImpulseOff);
-        ls_impulsor_fuelDrain_1 = 0;
-        ls_impulsor_fuelDrain_2 = 0;
-        // ls_impulsor_boostSpeed_1 = 400; // Impulse speeds, default values listed
-        // ls_impulsor_boostSpeed_2 = 600;
+        IMPULSE_SETTINGS;
 
         backRotorForceCoef = 1.8;
         backRotorSpeed = 1;
@@ -94,13 +89,13 @@ class CfgVehicles {
                 onlyforplayer = 0;
                 hideOnUse = 1;
 
-                condition = QUOTE(isEngineOn this and ace_player == currentPilot this and !isTouchingGround this);
-                statement = QUOTE(this call ls_vehicle_fnc_ImpulseJoystick);
+                condition = QUOTE(this call FUNC(canImpulse));
+                statement = QUOTE(this call ls_vehicle_fnc_impulseJoystick);
             };
             class Repulse: Impulse {
                 displayName = "Repulse";
                 shortcut = "User20";
-                statement = QUOTE(this call ls_vehicle_fnc_RepulseJoystick);
+                statement = QUOTE(this call ls_vehicle_fnc_repulseJoystick);
             };
 
             class LoadVehicle: Impulse {

--- a/addons/vehicles/air/laatc/CfgVehicles.hpp
+++ b/addons/vehicles/air/laatc/CfgVehicles.hpp
@@ -86,7 +86,7 @@ class CfgVehicles {
                 radius = 5;
 
                 shortcut = "User19";
-                onlyforplayer = 0;
+                onlyForPlayer = 0;
                 hideOnUse = 1;
 
                 condition = QUOTE(this call FUNC(canImpulse));

--- a/addons/vehicles/air/laati/CfgVehicles.hpp
+++ b/addons/vehicles/air/laati/CfgVehicles.hpp
@@ -25,11 +25,7 @@ class CfgVehicles {
         vehicleClass = "Helicopter";
         availableForSupportTypes[] = {"CAS_Heli", "Transport", "Drop"};
 
-        tas_can_impulse = FALSE;
-        ls_impulsor_soundOn = QCLASS(Sound_ImpulseOn);
-        ls_impulsor_soundOff = QCLASS(Sound_ImpulseOff);
-        ls_impulsor_fuelDrain_1 = 0;
-        ls_impulsor_fuelDrain_2 = 0;
+        IMPULSE_SETTINGS;
 
         ls_vehicle_rampAnims[] = {"ramp"};
         ls_vehicle_rampToggleSounds[] = {QCLASS(Sound_LAAT_Ramp), QCLASS(Sound_LAAT_Ramp)};
@@ -189,12 +185,12 @@ class CfgVehicles {
                 hideOnUse = TRUE;
                 showWindow = FALSE;
 
-                condition = QUOTE(isEngineOn this and ace_player == currentPilot this and !isTouchingGround this;);
-                statement = QUOTE(this call ls_vehicle_fnc_ImpulseJoystick;);
+                condition = QUOTE(this call FUNC(canImpulse));
+                statement = QUOTE(this call ls_vehicle_fnc_impulseJoystick;);
             };
             class Repulse: Impulse {
                 displayName = "Repulse";
-                statement = QUOTE(this call ls_vehicle_fnc_RepulseJoystick;);
+                statement = QUOTE(this call ls_vehicle_fnc_repulseJoystick;);
             };
 
             class DoorsOpen: Impulse {

--- a/addons/vehicles/air/laati/CfgVehicles.hpp
+++ b/addons/vehicles/air/laati/CfgVehicles.hpp
@@ -181,7 +181,7 @@ class CfgVehicles {
                 radius = 5;
                 priority = 9;
 
-                onlyforplayer = FALSE;
+                onlyForPlayer = FALSE;
                 hideOnUse = TRUE;
                 showWindow = FALSE;
 

--- a/addons/vehicles/air/nu/CfgVehicles.hpp
+++ b/addons/vehicles/air/nu/CfgVehicles.hpp
@@ -8,7 +8,6 @@ class CfgVehicles {
     };
     class 3AS_Nu_REP_F: 3AS_Nu_Base_F {
         class ACE_SelfActions;
-        class UserActions;
     };
     class CLASS(Nu): 3AS_Nu_REP_F {
         SCOPE_PUBLIC;
@@ -110,10 +109,10 @@ class CfgVehicles {
                 statement = QUOTE(this call ls_vehicle_fnc_repulseJoystick;);
             };
             class RampOpen: RampOpen {
-                condition = QUOTE(ace_player == currentPilot this and {this animationSourcePhase 'ramp' == 0} and {alive this});
+                condition = QUOTE(alive this and {this animationSourcePhase 'ramp' == 0});
             };
             class RampClose: RampClose {
-                condition = QUOTE(ace_player == currentPilot this and {this animationSourcePhase 'ramp' == 1} and {alive this});
+                condition = QUOTE(alive this and {this animationSourcePhase 'ramp' == 1});
             };
         };
 

--- a/addons/vehicles/air/nu/CfgVehicles.hpp
+++ b/addons/vehicles/air/nu/CfgVehicles.hpp
@@ -102,11 +102,11 @@ class CfgVehicles {
                 showWindow = FALSE;
 
                 condition = QUOTE(this call FUNC(canImpulse));
-                statement = QUOTE(this call ls_vehicle_fnc_impulseJoystick;);
+                statement = QUOTE(this call ls_vehicle_fnc_impulseJoystick);
             };
             class ImpulseOff: ImpulseOn {
                 displayName = "Repulse";
-                statement = QUOTE(this call ls_vehicle_fnc_repulseJoystick;);
+                statement = QUOTE(this call ls_vehicle_fnc_repulseJoystick);
             };
             class RampOpen: RampOpen {
                 condition = QUOTE(alive this and {this animationSourcePhase 'ramp' == 0});

--- a/addons/vehicles/air/nu/CfgVehicles.hpp
+++ b/addons/vehicles/air/nu/CfgVehicles.hpp
@@ -97,7 +97,7 @@ class CfgVehicles {
                 radius = 5;
                 priority = 9;
 
-                onlyforplayer = FALSE;
+                onlyForPlayer = FALSE;
                 hideOnUse = TRUE;
                 showWindow = FALSE;
 

--- a/addons/vehicles/air/nu/CfgVehicles.hpp
+++ b/addons/vehicles/air/nu/CfgVehicles.hpp
@@ -1,7 +1,14 @@
 class CfgVehicles {
-    class 3AS_Nu_Base_F;
+    class Helicopter_Base_H;
+    class 3AS_Nu_Base_F: Helicopter_Base_H {
+        class UserActions {
+            class RampOpen;
+            class RampClose;
+        };
+    };
     class 3AS_Nu_REP_F: 3AS_Nu_Base_F {
         class ACE_SelfActions;
+        class UserActions;
     };
     class CLASS(Nu): 3AS_Nu_REP_F {
         SCOPE_PUBLIC;
@@ -15,11 +22,7 @@ class CfgVehicles {
         crew = QCLASS(Unit_Phase2_CXA);
         typicalCargo[] = {QCLASS(Unit_Phase2_CXA)};
 
-        tas_can_impulse = FALSE;
-        ls_impulsor_soundOn = QCLASS(Sound_ImpulseOn);
-        ls_impulsor_soundOff = QCLASS(Sound_ImpulseOff);
-        ls_impulsor_fuelDrain_1 = 0;
-        ls_impulsor_fuelDrain_2 = 0;
+        IMPULSE_SETTINGS;
 
         weapons[] = {
             "ParticleBeamCannon_Nu",
@@ -86,6 +89,32 @@ class CfgVehicles {
 
         class ACE_SelfActions: ACE_SelfActions {
             HUD_CHANGER;
+        };
+
+        class UserActions: UserActions {
+            class ImpulseOn {
+                displayName = "Impulse";
+                position = "pilotview";
+                radius = 5;
+                priority = 9;
+
+                onlyforplayer = FALSE;
+                hideOnUse = TRUE;
+                showWindow = FALSE;
+
+                condition = QUOTE(this call FUNC(canImpulse));
+                statement = QUOTE(this call ls_vehicle_fnc_impulseJoystick;);
+            };
+            class ImpulseOff: ImpulseOn {
+                displayName = "Repulse";
+                statement = QUOTE(this call ls_vehicle_fnc_repulseJoystick;);
+            };
+            class RampOpen: RampOpen {
+                condition = QUOTE(ace_player == currentPilot this and {this animationSourcePhase 'ramp' == 0} and {alive this});
+            };
+            class RampClose: RampClose {
+                condition = QUOTE(ace_player == currentPilot this and {this animationSourcePhase 'ramp' == 1} and {alive this});
+            };
         };
 
         INVENTORY_VEHICLE_BASE(3);

--- a/addons/vehicles/air/rho/CfgVehicles.hpp
+++ b/addons/vehicles/air/rho/CfgVehicles.hpp
@@ -1,5 +1,11 @@
 class CfgVehicles {
-    class 3AS_Rho_Base_F;
+    class Helicopter_Base_H;
+    class 3AS_Rho_Base_F: Helicopter_Base_H {
+        class UserActions {
+            class RampOpen;
+            class RampClose;
+        };
+    };
     class 3AS_Rho_REP_F: 3AS_Rho_Base_F {
         class ACE_SelfActions;
     };
@@ -15,11 +21,7 @@ class CfgVehicles {
         crew = QCLASS(Unit_Phase2_CXA);
         typicalCargo[] = {QCLASS(Unit_Phase2_CXA)};
 
-        tas_can_impulse = FALSE;
-        ls_impulsor_soundOn = QCLASS(Sound_ImpulseOn);
-        ls_impulsor_soundOff = QCLASS(Sound_ImpulseOff);
-        ls_impulsor_fuelDrain_1 = 0;
-        ls_impulsor_fuelDrain_2 = 0;
+        IMPULSE_SETTINGS;
 
         weapons[] = {
             "ParticleBeamCannon_Nu",
@@ -82,6 +84,32 @@ class CfgVehicles {
 
         class ACE_SelfActions: ACE_SelfActions {
             HUD_CHANGER;
+        };
+
+        class UserActions: UserActions {
+            class ImpulseOn {
+                displayName = "Impulse";
+                position = "pilotview";
+                radius = 5;
+                priority = 9;
+
+                onlyforplayer = FALSE;
+                hideOnUse = TRUE;
+                showWindow = FALSE;
+
+                condition = QUOTE(this call FUNC(canImpulse));
+                statement = QUOTE(this call ls_vehicle_fnc_impulseJoystick;);
+            };
+            class ImpulseOff: ImpulseOn {
+                displayName = "Repulse";
+                statement = QUOTE(this call ls_vehicle_fnc_repulseJoystick;);
+            };
+            class RampOpen: RampOpen {
+                condition = QUOTE(ace_player == currentPilot this and {this animationSourcePhase 'ramp' == 0} and {alive this});
+            };
+            class RampClose: RampClose {
+                condition = QUOTE(ace_player == currentPilot this and {this animationSourcePhase 'ramp' == 1} and {alive this});
+            };
         };
 
         INVENTORY_VEHICLE_BASE(3);

--- a/addons/vehicles/air/rho/CfgVehicles.hpp
+++ b/addons/vehicles/air/rho/CfgVehicles.hpp
@@ -90,7 +90,7 @@ class CfgVehicles {
                 radius = 5;
                 priority = 9;
 
-                onlyforplayer = FALSE;
+                onlyForPlayer = FALSE;
                 hideOnUse = TRUE;
                 showWindow = FALSE;
 

--- a/addons/vehicles/air/rho/CfgVehicles.hpp
+++ b/addons/vehicles/air/rho/CfgVehicles.hpp
@@ -162,8 +162,9 @@ class CfgVehicles {
 
         crew = QCLASS(Unit_Phase2_CT);
 
-        textureList[] = {"Republic", 1, "Imperial", 0};
+        ace_cargo_space = 50;
 
+        textureList[] = {"Republic", 1, "Imperial", 0};
         class TextureSources {
             class Standard {
                 author = "3rd Army Studios";
@@ -233,6 +234,12 @@ class CfgVehicles {
                     "\3AS\3AS_republic_heli\rho_class\data\clone_bed_co.paa",
                     "\3AS\3AS_republic_heli\rho_class\data\interior_co.paa"
                 };
+            };
+        };
+
+        class ACE_Cargo {
+            class Cargo {
+                CARGO_XX(CLASS(Resupply_platoonMedical),1);
             };
         };
     };

--- a/addons/vehicles/air/rho/CfgVehicles.hpp
+++ b/addons/vehicles/air/rho/CfgVehicles.hpp
@@ -1,7 +1,10 @@
 class CfgVehicles {
     class Helicopter_Base_H;
     class 3AS_Rho_Base_F: Helicopter_Base_H {
-        class UserActions;
+        class UserActions {
+            class RampOpen;
+            class RampClose;
+        };
     };
     class 3AS_Rho_REP_F: 3AS_Rho_Base_F {
         class ACE_SelfActions;
@@ -84,6 +87,8 @@ class CfgVehicles {
         };
 
         class UserActions: UserActions {
+            // Impulse actions don't appear for some reason, I cannot figure out why
+            // Keybind works fine
             class ImpulseOn {
                 displayName = "Impulse";
                 position = "pilotview";
@@ -95,11 +100,11 @@ class CfgVehicles {
                 showWindow = FALSE;
 
                 condition = QUOTE(this call FUNC(canImpulse));
-                statement = QUOTE(this call ls_vehicle_fnc_impulseJoystick;);
+                statement = QUOTE(this call ls_vehicle_fnc_impulseJoystick);
             };
             class ImpulseOff: ImpulseOn {
                 displayName = "Repulse";
-                statement = QUOTE(this call ls_vehicle_fnc_repulseJoystick;);
+                statement = QUOTE(this call ls_vehicle_fnc_repulseJoystick);
             };
             class RampOpen: RampOpen {
                 condition = QUOTE(alive this and {this animationSourcePhase 'ramp' == 0});

--- a/addons/vehicles/air/rho/CfgVehicles.hpp
+++ b/addons/vehicles/air/rho/CfgVehicles.hpp
@@ -1,10 +1,7 @@
 class CfgVehicles {
     class Helicopter_Base_H;
     class 3AS_Rho_Base_F: Helicopter_Base_H {
-        class UserActions {
-            class RampOpen;
-            class RampClose;
-        };
+        class UserActions;
     };
     class 3AS_Rho_REP_F: 3AS_Rho_Base_F {
         class ACE_SelfActions;
@@ -105,10 +102,10 @@ class CfgVehicles {
                 statement = QUOTE(this call ls_vehicle_fnc_repulseJoystick;);
             };
             class RampOpen: RampOpen {
-                condition = QUOTE(ace_player == currentPilot this and {this animationSourcePhase 'ramp' == 0} and {alive this});
+                condition = QUOTE(alive this and {this animationSourcePhase 'ramp' == 0});
             };
             class RampClose: RampClose {
-                condition = QUOTE(ace_player == currentPilot this and {this animationSourcePhase 'ramp' == 1} and {alive this});
+                condition = QUOTE(alive this and {this animationSourcePhase 'ramp' == 1});
             };
         };
 

--- a/addons/vehicles/functions/fnc_canImpulse.sqf
+++ b/addons/vehicles/functions/fnc_canImpulse.sqf
@@ -16,5 +16,6 @@
  */
 
 params ["_vehicle"];
+TRACE_1("fnc_canImpulse",_vehicle);
 
 isEngineOn _vehicle and {ace_player == currentPilot _vehicle} and {!isTouchingGround _vehicle};

--- a/addons/vehicles/functions/fnc_canImpulse.sqf
+++ b/addons/vehicles/functions/fnc_canImpulse.sqf
@@ -1,0 +1,20 @@
+#include "..\script_component.hpp"
+/*
+ * Author: DartRuffian
+ * Determines whether a player can activate a vehicle's impulse.
+ *
+ * Arguments:
+ * 0: The vehicle <OBJECT>
+ *
+ * Return Value:
+ * True if the vehicle can impulse, otherwise false <BOOL>
+ *
+ * Examples:
+ * (objectParent ace_player) call BNA_KC_vehicles_fnc_canImpulse;
+ *
+ * Public: No
+ */
+
+params ["_vehicle"];
+
+isEngineOn _vehicle and {ace_player == currentPilot _vehicle} and {!isTouchingGround _vehicle};

--- a/addons/vehicles/land/blitz/CfgVehicles.hpp
+++ b/addons/vehicles/land/blitz/CfgVehicles.hpp
@@ -217,10 +217,7 @@ class CfgVehicles {
 
         class ACE_Cargo {
             class Cargo {
-                class Track {
-                    type = "ACE_Track";
-                    amount = 1;
-                };
+                CARGO_XX(ACE_TRACK,1);
             };
         };
     };

--- a/addons/vehicles/script_macros.hpp
+++ b/addons/vehicles/script_macros.hpp
@@ -2,6 +2,14 @@
 
 #define VIV_PICKUP_RANGE 30
 
+#define IMPULSE_SETTINGS tas_can_impulse = FALSE; \
+ls_impulsor_soundOn = QCLASS(Sound_ImpulseOn); \
+ls_impulsor_soundOff = QCLASS(Sound_ImpulseOff); \
+ls_impulsor_boostSpeed_1 = 400; \
+ls_impulsor_boostSpeed_2 = 600; \
+ls_impulsor_fuelDrain_1 = 0; \
+ls_impulsor_fuelDrain_2 = 0 \
+
 #define SKIN_SWITCHER class GVAR(switchSkin) { \
     displayName = "Switch Vehicle Skin"; \
     condition = QUOTE(call FUNC(skin_canSwitch)); \


### PR DESCRIPTION
## Description
Small changes to the Nu-class and Rho-class shuttles.

<!--
If multiple components are being modified, add **Component Name** to the beginning of each list.
e.g.
**Core**
- Change 1

**Weapons**
- Change 1
-->
## Changes
- Rho-class
  - Fixed impulse action using 3AS impulse
- Rho crates
  - Increased ACE cargo space to 50
  - Add platoon medical crate to medical rho crate
- Nu-class
  - Fixed impulse action using 3AS impulse
  - Current issue with impulse actions not appearing, unknown cause.