### PR TITLE
Zeus - Hide group marker for Zeus while in interface

### DIFF
--- a/addons/zeus/$PBOPREFIX$
+++ b/addons/zeus/$PBOPREFIX$
@@ -1,0 +1,1 @@
+ORA\BNA_KC\addons\zeus

--- a/addons/zeus/CfgEventHandlers.hpp
+++ b/addons/zeus/CfgEventHandlers.hpp
@@ -1,0 +1,11 @@
+class Extended_PreStart_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_SCRIPT(XEH_preStart));
+    };
+};
+
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_SCRIPT(XEH_preInit));
+    };
+};

--- a/addons/zeus/CfgEventHandlers.hpp
+++ b/addons/zeus/CfgEventHandlers.hpp
@@ -9,3 +9,9 @@ class Extended_PreInit_EventHandlers {
         init = QUOTE(call COMPILE_SCRIPT(XEH_preInit));
     };
 };
+
+class Extended_PostInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_SCRIPT(XEH_postInit));
+    };
+};

--- a/addons/zeus/README.md
+++ b/addons/zeus/README.md
@@ -1,0 +1,2 @@
+# Zeus
+Small tweaks and additions to Zeus.

--- a/addons/zeus/XEH_PREP.hpp
+++ b/addons/zeus/XEH_PREP.hpp
@@ -1,0 +1,1 @@
+PREP(onMenuOpen);

--- a/addons/zeus/XEH_postInit.sqf
+++ b/addons/zeus/XEH_postInit.sqf
@@ -1,0 +1,5 @@
+#include "script_component.hpp"
+
+if (hasInterface) then {
+    call COMPILE_SCRIPT(XEH_postInitClient);
+};

--- a/addons/zeus/XEH_postInitClient.sqf
+++ b/addons/zeus/XEH_postInitClient.sqf
@@ -1,0 +1,5 @@
+#include "script_component.hpp"
+
+["CBA_settingsInitialized", {
+    ["featureCamera", LINKFUNC(onMenuOpen)] call CBA_fnc_addPlayerEventHandler;
+}] call CBA_fnc_addEventHandler;

--- a/addons/zeus/XEH_preInit.sqf
+++ b/addons/zeus/XEH_preInit.sqf
@@ -1,0 +1,7 @@
+#include "script_component.hpp"
+
+PREP_RECOMPILE_START;
+#include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
+
+ADDON = true;

--- a/addons/zeus/XEH_preInit.sqf
+++ b/addons/zeus/XEH_preInit.sqf
@@ -4,4 +4,6 @@ PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
 PREP_RECOMPILE_END;
 
+#include "initSettings.inc.sqf"
+
 ADDON = true;

--- a/addons/zeus/XEH_preStart.sqf
+++ b/addons/zeus/XEH_preStart.sqf
@@ -1,0 +1,3 @@
+#include "script_component.hpp"
+
+#include "XEH_PREP.hpp"

--- a/addons/zeus/config.cpp
+++ b/addons/zeus/config.cpp
@@ -1,0 +1,17 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        author = AUTHOR;
+        name = COMPONENT_NAME;
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {
+            QCLASS(core)
+        };
+        units[] = {};
+        weapons[] = {};
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgEventHandlers.hpp"

--- a/addons/zeus/functions/fnc_onMenuOpen.sqf
+++ b/addons/zeus/functions/fnc_onMenuOpen.sqf
@@ -20,6 +20,8 @@ params ["_player", "_camera"];
 TRACE_2("fnc_onMenuOpen",_player,_camera);
 
 // Hide blueforce tracker
-group _player setVariable ["ace_map_hideBlueForceMarker", _camera == "curator", true];
+if (GVAR(hideZeusGroup)) then {
+    group _player setVariable ["ace_map_hideBlueForceMarker", _camera == "curator", true];
+};
 
 nil;

--- a/addons/zeus/functions/fnc_onMenuOpen.sqf
+++ b/addons/zeus/functions/fnc_onMenuOpen.sqf
@@ -1,0 +1,25 @@
+#include "..\script_component.hpp"
+/*
+ * Author: DartRuffian
+ * Called when the Zeus interface is opened.
+ *
+ * Arguments:
+ * 0: Player unit <OBJECT>
+ * 1: Type of feature camera <STRING>
+ *
+ * Return Value:
+ * None
+ *
+ * Examples:
+ * ["featureCamera", BNA_KC_zeus_onMenuOpen] call CBA_fnc_addPlayerEventHandler;
+ *
+ * Public: No
+ */
+
+params ["_player", "_camera"];
+TRACE_2("fnc_onMenuOpen",_player,_camera);
+
+// Hide blueforce tracker
+group _player setVariable ["ace_map_hideBlueForceMarker", _camera == "curator", true];
+
+nil;

--- a/addons/zeus/initSettings.inc.sqf
+++ b/addons/zeus/initSettings.inc.sqf
@@ -1,0 +1,8 @@
+[
+    QGVAR(hideZeusGroup),
+    "CHECKBOX",
+    ["Hide Group Marker in Zeus", "If enabled, the group marker, from ACE's Blue Force Tracker, for a Zues's group will be hidden while in the Zeus interface."],
+    [QUOTE(MOD_NAME), QUOTE(COMPONENT_BEAUTIFIED)],
+    true,
+    TRUE
+] call CBA_fnc_addSetting;

--- a/addons/zeus/script_component.hpp
+++ b/addons/zeus/script_component.hpp
@@ -1,0 +1,8 @@
+#define COMPONENT zeus
+#define COMPONENT_BEAUTIFIED Zeus
+#include "\ORA\BNA_KC\addons\core\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+
+#include "\ORA\BNA_KC\addons\core\script_macros.hpp"

--- a/addons/zeus/script_component.hpp
+++ b/addons/zeus/script_component.hpp
@@ -2,7 +2,7 @@
 #define COMPONENT_BEAUTIFIED Zeus
 #include "\ORA\BNA_KC\addons\core\script_mod.hpp"
 
-#define DEBUG_MODE_FULL
-#define DISABLE_COMPILE_CACHE
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
 
 #include "\ORA\BNA_KC\addons\core\script_macros.hpp"

--- a/addons/zeus/script_component.hpp
+++ b/addons/zeus/script_component.hpp
@@ -2,7 +2,7 @@
 #define COMPONENT_BEAUTIFIED Zeus
 #include "\ORA\BNA_KC\addons\core\script_mod.hpp"
 
-// #define DEBUG_MODE_FULL
-// #define DISABLE_COMPILE_CACHE
+#define DEBUG_MODE_FULL
+#define DISABLE_COMPILE_CACHE
 
 #include "\ORA\BNA_KC\addons\core\script_macros.hpp"


### PR DESCRIPTION
## Description
Hides the group marker added by ACE's Blue Force Tracking system for a zeus's group while in the Zeus interface.

<!--
If multiple components are being modified, add **Component Name** to the beginning of each list.
e.g.
**Core**
- Change 1

**Weapons**
- Change 1
-->
## Changes
- Added Zeus addon.
- Added a setting for whether to hide the group marker or not.