### PR TITLE
Weapons - Fix AI fire rate for Westar-M5

### DIFF
--- a/addons/weapons/westar_m5/CfgWeapons.hpp
+++ b/addons/weapons/westar_m5/CfgWeapons.hpp
@@ -86,6 +86,7 @@ class CfgWeapons {
         };
         class FullAuto: FullAuto {
             sounds[] = {"StandardSound"};
+            aiRateOfFire = 2;
             class StandardSound: StandardSound {
                 soundSetShot[] = {QCLASS(SoundSet_WestarM5Shot)};
                 soundSetShotWater[] = {QCLASS(SoundSet_WestarM5Shot)};


### PR DESCRIPTION
## Description
Fix the `aiFireRate` for the Westar-M5 being a negative number, weird issue on 3AS's end.

<!--
If multiple components are being modified, add **Component Name** to the beginning of each list.
e.g.
**Core**
- Change 1

**Weapons**
- Change 1
-->
## Changes
- Fixed `aiFireRate` for Westar-M5