### PR TITLE
Core/Objects - Updated Engineer permissions

### DIFF
--- a/addons/core/functions/fnc_isEngineer.sqf
+++ b/addons/core/functions/fnc_isEngineer.sqf
@@ -7,10 +7,10 @@
  * 0: Unit <OBJECT>
  *
  * Return Value:
- * True if unit is an engineer, otherwise false
+ * True if unit is an engineer, otherwise false <BOOL>
  *
  * Example:
- * player call FUNC(isEngineer)
+ * player call BNA_KC_core_fnc_isEngineer
  *
  * Public: Yes
  */
@@ -20,4 +20,4 @@ params [
 ];
 TRACE_1("fnc_isEngineer",_unit);
 
-_unit getVariable ["ace_isEngineer", false];
+_unit getVariable ["ace_isEngineer", false] in [1, 2, true];

--- a/addons/core/functions/fnc_isMedic.sqf
+++ b/addons/core/functions/fnc_isMedic.sqf
@@ -7,10 +7,10 @@
  * 0: Unit <OBJECT>
  *
  * Return Value:
- * True if unit is a medic, otherwise false
+ * True if unit is a medic, otherwise false <BOOL>
  *
  * Example:
- * player call FUNC(isEngineer)
+ * player call BNA_KC_core_fnc_isEngineer
  *
  * Public: Yes
  */

--- a/addons/core/functions/fnc_setEngineer.sqf
+++ b/addons/core/functions/fnc_setEngineer.sqf
@@ -13,16 +13,17 @@
  * None
  *
  * Example:
- * [player, false] call FUNC(setEngineer)
+ * [player, false] call BNA_KC_core_fnc_setEngineer;
  *
  * Public: Yes
  */
 
 params [
     ["_unit", objNull, [objNull]],
-    ["_state", true, [true]]
+    ["_state", 1, [true, 1]]
 ];
 TRACE_2("fnc_setEngineer",_unit,_state);
 
 _unit setUnitTrait ["Engineer", false]; // Should always be false because of ACE Repair
 _unit setVariable ["ace_isEngineer", _state, true];
+nil;

--- a/addons/core/functions/fnc_setMedic.sqf
+++ b/addons/core/functions/fnc_setMedic.sqf
@@ -11,7 +11,7 @@
  * None
  *
  * Example:
- * [player, 1] call FUNC(setMedic)
+ * [player, 1] call BNA_KC_core_fnc_setMedic;
  *
  * Public: Yes
  */

--- a/addons/objects/CfgVehicles.hpp
+++ b/addons/objects/CfgVehicles.hpp
@@ -99,12 +99,12 @@ class CfgVehicles {
             class Assign_Engineer: Assign_Medic {
                 displayName = QUOTE(<t color='#f0be00'><img image=QQPATHTOEF(core,data\ui\EOD_White_ca.paa)/> Assign Engineer Permissions</t>);
                 condition = QUOTE(!(ace_player call EFUNC(core,isEngineer)));
-                statement = QUOTE([ARR_2(ace_player,true)] call EFUNC(core,setEngineer));
+                statement = QUOTE([ARR_2(ace_player,2)] call EFUNC(core,setEngineer));
             };
             class Unassign_Engineer: Assign_Engineer {
                 displayName = QUOTE(<t color='#f0be00'><img image=QQPATHTOEF(core,data\ui\EOD_White_ca.paa)/> Unassign Engineer Permissions</t>);
                 condition = QUOTE(ace_player call EFUNC(core,isEngineer));
-                statement = QUOTE([ARR_2(ace_player,false)] call EFUNC(core,setEngineer));
+                statement = QUOTE([ARR_2(ace_player,0)] call EFUNC(core,setEngineer));
             };
         };
     };


### PR DESCRIPTION
## Description
Updated is/setEngineer functions. Permissions gonk sets engineers to advanced level.

<!--
If multiple components are being modified, add **Component Name** to the beginning of each list.
e.g.
**Core**
- Change 1

**Weapons**
- Change 1
-->
## Changes
**Core**
- `fnc_setEngineer` can take a number for engineer level
- `fnc_isEngineer` checks for engineer level in array of `[1, 2, false]`

**Objects**
- Permissions gonk sets engineers to advanced