### PR TITLE
Jetpacks - Small refactor for particle effects

### DIFF
--- a/addons/armor/CfgVehicles.hpp
+++ b/addons/armor/CfgVehicles.hpp
@@ -369,7 +369,10 @@ class CfgVehicles {
         EGVAR(jetpacks,canHover) = TRUE;
 
         // Effects
-        EGVAR(jetpacks,effectPoints)[] = {"effect_left", "effect_right"};
+        EGVAR(jetpacks,effectPoints)[] = {
+            {-0.13251, -0.219357, -0.247619},
+            { 0.15051, -0.219357, -0.247619}
+        };
         EGVAR(jetpacks,effects)[] = {
             QCLASS(cloudlet_jetpackFire_blue),
             QCLASS(cloudlet_jetpackSmoke)
@@ -405,6 +408,11 @@ class CfgVehicles {
         EGVAR(jetpacks,speed) = 2;
         EGVAR(jetpacks,fuel) = 50;
         EGVAR(jetpacks,canHover) = FALSE;
+
+        EGVAR(jetpacks,effectPoints)[] = {
+            {-0.0753933, -0.239498, -0.149011},
+            { 0.0933938, -0.239498, -0.149011}
+        };
     };
 
     class CLASS(Jetpack_CDV21_LR): CLASS(Jetpack_CDV21) {
@@ -429,7 +437,9 @@ class CfgVehicles {
         picture = "\MRC\JLTS\characters\CloneArmor\data\ui\Clone_jumppack_mc_ui_ca.paa";
 
         EGVAR(jetpacks,fuel) = 75;
-        EGVAR(jetpacks,effectPoints)[] = {"effect"};
+        EGVAR(jetpacks,effectPoints)[] = {
+            {0.00900585, -0.212387, -0.16184}
+        };
     };
 
     class CLASS(Jetpack_CDV19_LR): CLASS(Jetpack_CDV19) {

--- a/addons/factions/cis/configs/Backpacks.hpp
+++ b/addons/factions/cis/configs/Backpacks.hpp
@@ -149,7 +149,10 @@ class CLASS(CIS_Jetpack_Droid_B1): CLASS(CIS_Backpack_Droid_B1) {
     EGVAR(jetpacks,strength) = JETPACK_STRENGTH_DEFAULT;
     EGVAR(jetpacks,canHover) = TRUE;
 
-    EGVAR(jetpacks,effectPoints)[] = {"effect_left", "effect_right"};
+    EGVAR(jetpacks,effectPoints)[] = {
+        {-0.146924, -0.21555, -0.0638125},
+        { 0.164924, -0.21555, -0.0638125}
+    };
     EGVAR(jetpacks,effects)[] = {
         QCLASS(cloudlet_jetpackFire_blue),
         QCLASS(cloudlet_jetpackSmoke)


### PR DESCRIPTION
## Description
Updated jetpack effects to also accept an array offset instead of a memory point name.

<!--
If multiple components are being modified, add **Component Name** to the beginning of each list.
e.g.
**Core**
- Change 1

**Weapons**
- Change 1
-->
## Changes
- `fnc_createEffects` checks each element in `BNA_KC_jetpacks_effectSources`.
  - If string, get position of memory point, and use that for particle.
  - If array, use array as position for particle.
- Updated all jetpacks to use array positions instead of memory point names.