### PR TITLE
Small cleanup for standalone release

### DIFF
--- a/addons/core/CfgEditorSubcategories.hpp
+++ b/addons/core/CfgEditorSubcategories.hpp
@@ -54,4 +54,7 @@ class CfgEditorSubcategories {
     class EDSUBCAT(Utility) {
         displayName = "Utility";
     };
+    class EDSUBCAT(Resupply) {
+        displayName = "Resupply";
+    };
 };

--- a/addons/jetpacks/CfgEventHandlers.hpp
+++ b/addons/jetpacks/CfgEventHandlers.hpp
@@ -19,7 +19,7 @@ class Extended_PostInit_EventHandlers {
 class Extended_Init_EventHandlers {
     class CLASS(Resupply_JetpackFuel) {
         class GVAR(refuel) {
-            init = QUOTE(_this#0 lockInventory true; _this#0 call FUNC(addRefuelAction));
+            init = QUOTE(_this call FUNC(addRefuelAction));
         };
     };
 };

--- a/addons/jetpacks/CfgVehicles.hpp
+++ b/addons/jetpacks/CfgVehicles.hpp
@@ -41,18 +41,27 @@ class CfgVehicles {
         };
     };
 
-    class CLASS(Resupply_Base);
-    class CLASS(Resupply_JetpackFuel): CLASS(Resupply_Base) {
+    class Land_WaterTank_F;
+    class CLASS(resupply_jetpackFuel): Land_WaterTank_F {
+        SCOPE_PUBLIC;
+        author = AUTHOR;
         displayName = "Jetpack Fuel Tank";
 
-        ace_cargo_size = 2;
-        ace_dragging_canDrag = FALSE;
-        ace_dragging_canCarry = FALSE;
+        editorCategory = QEDCAT(objects);
+        editorSubcategory = QEDSUBCAT(resupply);
+        editorPreview = "\A3\EditorPreviews_F\Data\CfgVehicles\Land_WaterTank_F.jpg";
 
         model = "\A3\Structures_F\Items\Vessels\WaterTank_F.p3d";
-        editorPreview = "\A3\EditorPreviews_F\Data\CfgVehicles\Land_WaterTank_F.jpg";
         hiddenSelections[] = {};
         hiddenSelectionsMaterials[] = {};
         hiddenSelectionsTextures[] = {};
+
+        ace_cargo_canLoad = TRUE;
+        ace_cargo_size = 2;
+        ace_cargo_noRename = TRUE;
+
+        // For if/when the property is renamed
+        ace_field_rations_waterSupply = 0;
+        acex_field_rations_waterSupply = 0;
     };
 };

--- a/addons/jetpacks/config.cpp
+++ b/addons/jetpacks/config.cpp
@@ -8,12 +8,11 @@ class CfgPatches {
         requiredAddons[] = {
             QCLASS(core),
             QCLASS(particles),
-            QEGVAR(objects,resupply),
             "ace_refuel",
             "ace_parachute"
         };
         units[] = {
-            QCLASS(Resupply_JetpackFuel)
+            QCLASS(resupply_jetpackFuel)
         };
         weapons[] = {
             QGVAR(fuelCan_empty),

--- a/addons/objects/CfgEditorSubcategories.hpp
+++ b/addons/objects/CfgEditorSubcategories.hpp
@@ -6,8 +6,4 @@ class CfgEditorSubcategories {
     class EDSUBCAT(StaticShips) {
         displayName = "Static Ships";
     };
-
-    class EDSUBCAT(Resupply) {
-        displayName = "Resupply";
-    };
 };

--- a/addons/objects/resupply/CfgVehicles.hpp
+++ b/addons/objects/resupply/CfgVehicles.hpp
@@ -13,8 +13,9 @@ class CfgVehicles {
         editorSubcategory = QEDSUBCAT(Resupply);
         editorPreview = EDITOR_PREVIEW(Resupply_Base);
 
-        ace_cargo_size = 1;
+        ace_cargo_canLoad = TRUE;
         ace_cargo_noRename = TRUE;
+        ace_cargo_size = 1;
 
         ace_dragging_canDrag = TRUE;
         ace_dragging_dragDirection = 90;


### PR DESCRIPTION
## Description
Small cleanup for stand-alone release for jetpacks.

<!--
If multiple components are being modified, add **Component Name** to the beginning of each list.
e.g.
**Core**
- Change 1

**Weapons**
- Change 1
-->
## Changes
- Moved resupply subcategory to core.
- Updated jetpack fuel resupply to inherit from vanilla class.