### PR TITLE
Jetpacks - Safe Ejection Tweak

### DIFF
--- a/addons/jetpacks/functions/fnc_getOutMan.sqf
+++ b/addons/jetpacks/functions/fnc_getOutMan.sqf
@@ -22,13 +22,15 @@
 params ["_unit", "", "_vehicle"];
 TRACE_2("fnc_getOutMan",_unit,_vehicle);
 
-if (_unit != ace_player or
-    {isTouchingGround _vehicle} or {
+if (_unit != ace_player or {
     !(_unit call FUNC(hasJetpack) or {
         private _backpack = backpack _unit;
         _backpack call JLTS_fnc_jumpIsJumppack;
     })
 }) exitWith {false};
+
+private _height = (getPosATL _vehicle) select 2;
+if (isTouchingGround _vehicle or {_height < 10}) exitWith {false};
 
 private _direction = getDir _vehicle;
 private _positionASL = getPosASL _vehicle vectorAdd [-GETOUT_SPACING * sin _direction, -GETOUT_SPACING * cos _direction, 0];


### PR DESCRIPTION
Updated safe ejection to not trigger if the vehicle is touching the ground *or* is less than 10 meters above the ground. This should hopefully prevent it from triggering on ground vehicles.

## Description
A clear and concise description of what changes were made.

<!--
If multiple components are being modified, add **Component Name** to the beginning of each list.
e.g.
**Core**
- Change 1

**Weapons**
- Change 1
-->
## Changes
- Safe ejection will not trigger if vehicle is less than 10 meters above the terrain.