### PR TITLE
Jetpacks - Small tweaks

### DIFF
--- a/addons/jetpacks/functions/fnc_getOutMan.sqf
+++ b/addons/jetpacks/functions/fnc_getOutMan.sqf
@@ -22,15 +22,17 @@
 params ["_unit", "", "_vehicle"];
 TRACE_2("fnc_getOutMan",_unit,_vehicle);
 
+if !(GVAR(easyEjection)) exitWith { false };
+
 if (_unit != ace_player or {
     !(_unit call FUNC(hasJetpack) or {
         private _backpack = backpack _unit;
         _backpack call JLTS_fnc_jumpIsJumppack;
     })
-}) exitWith {false};
+}) exitWith { false };
 
 private _height = (getPosATL _vehicle) select 2;
-if (isTouchingGround _vehicle or {_height < 10}) exitWith {false};
+if (isTouchingGround _vehicle or {_height < 10}) exitWith { false };
 
 private _direction = getDir _vehicle;
 private _positionASL = getPosASL _vehicle vectorAdd [-GETOUT_SPACING * sin _direction, -GETOUT_SPACING * cos _direction, 0];

--- a/addons/jetpacks/functions/fnc_jetpackPFH.sqf
+++ b/addons/jetpacks/functions/fnc_jetpackPFH.sqf
@@ -115,7 +115,8 @@ private _condition = {
 private _exitCode = {
     params ["", "_unit", "_jetpack", "_strength", "_speed", "_freefallHeight"];
     TRACE_5("Stopped jetpack",_unit,_jetpack,_strength,_speed,_freefallHeight);
-    _unit setUnitFreefallHeight -1;
+    private _originalHeight = _unit getVariable [QGVAR(freefallHeight), -1];
+    _unit setUnitFreefallHeight _originalHeight;
     [QGVAR(jetpackStopped), [_unit, _jetpack, _strength, _speed, _freefallHeight]] call CBA_fnc_globalEvent;
 };
 

--- a/addons/jetpacks/functions/fnc_jetpackStart.sqf
+++ b/addons/jetpacks/functions/fnc_jetpackStart.sqf
@@ -35,7 +35,9 @@ private _speed = getNumber (configOf _jetpack >> QGVAR(speed));
 private _freefallHeight = getNumber (configOf _jetpack >> QGVAR(freefallHeight));
 
 if (_freefallHeight > 0) then {
-    ace_player setUnitFreefallHeight _freefallHeight;
+    private _originalHeight = (getUnitFreefallInfo ace_player) select 2;
+    ace_player setVariable [QGVAR(freefallHeight), _originalHeight];
+    ace_player setUnitFreefallHeight (_freefallHeight max _originalHeight);
 };
 
 private _velocity = velocity ace_player;

--- a/addons/jetpacks/initSettings.inc.sqf
+++ b/addons/jetpacks/initSettings.inc.sqf
@@ -23,3 +23,11 @@
     [QUOTE(MOD_NAME), QUOTE(COMPONENT_BEAUTIFIED)],
     [0, 100, 20, -1]
 ] call CBA_fnc_addSetting;
+
+[
+    QGVAR(easyEjection),
+    "CHECKBOX",
+    ["Easy Ejection", "If enabled, ejecting from an airborne vehicle will automatically move the player ~30m behind the vehicle to prevent getting stuck inside."],
+    [QUOTE(MOD_NAME), QUOTE(COMPONENT_BEAUTIFIED)],
+    true
+] call CBA_fnc_addSetting;


### PR DESCRIPTION
Closes #267 

## Description
Adds a setting for the easy ejection.
Reset player freefall height to unit's height instead of engine default height.